### PR TITLE
fix event_loop db bug

### DIFF
--- a/code_court/courthouse/event_loop.py
+++ b/code_court/courthouse/event_loop.py
@@ -1,6 +1,8 @@
 import datetime
 from time import sleep
 
+from flask import Flask
+
 import model
 from model import db
 
@@ -19,13 +21,21 @@ def reset_overdue_runs():
     model.db.session.commit()
 
 def event_loop():
-    try:
-        while True:
-            reset_overdue_runs()
-            sleep(30)
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = "sqlite:////tmp/code_court.db"
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['model'] = model
 
-    except KeyboardInterrupt:
-        print("Event loop shutting down")
+    db.init_app(app)
+
+    with app.app_context():
+        try:
+            while True:
+                reset_overdue_runs()
+                sleep(30)
+
+        except KeyboardInterrupt:
+            print("Event loop shutting down")
 
 if __name__ == "__main__":
     event_loop()


### PR DESCRIPTION
Previously threw error when starting

```
[2017-03-21 21:37:01 -0500] [16510] [INFO] Starting gunicorn 19.6.0
[2017-03-21 21:37:01 -0500] [16510] [INFO] Listening at: http://0.0.0.0:9191 (16510)
[2017-03-21 21:37:01 -0500] [16510] [INFO] Using worker: sync
[2017-03-21 21:37:01 -0500] [16517] [INFO] Booting worker with pid: 16517
2017-03-21 21:37:02,315 - web.py - INFO - Creating db tables
2017-03-21 21:37:02,329 - web.py - INFO - Initializing db tables
Traceback (most recent call last):
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/sqlalchemy/util/_collections.py", line 988, in __call__
    return self.registry[key]
KeyError: 139817174684800

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "event_loop.py", line 31, in <module>
    event_loop()
  File "event_loop.py", line 24, in event_loop
    reset_overdue_runs()
  File "event_loop.py", line 10, in reset_overdue_runs
    runs = model.Run.query.filter(model.Run.finished_execing_time == None)\
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py", line 500, in __get__
    return type.query_class(mapper, session=self.sa.session())
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/sqlalchemy/orm/scoping.py", line 78, in __call__
    return self.registry()
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/sqlalchemy/util/_collections.py", line 990, in __call__
    return self.registry.setdefault(key, self.createfunc())
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py", line 771, in create_session
    return SignallingSession(self, **options)
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py", line 153, in __init__
    self.app = app = db.get_app()
  File "/home/ben/envs/courthouse/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py", line 922, in get_app
    raise RuntimeError('application not registered on db '
RuntimeError: application not registered on db instance and no application bound to current context
2017-03-21 21:37:02,465 - web.py - INFO - Initializing tables with dev data
[2017-03-21 21:37:11 -0500] [16510] [INFO] Handling signal: winch
```