### PR TITLE
fix initial problem loading bug

### DIFF
--- a/code_court/defendant-frontend/src/store/index.js
+++ b/code_court/defendant-frontend/src/store/index.js
@@ -21,10 +21,8 @@ const store = new Vuex.Store({
   },
   actions: {
     LOAD_PROBLEMS: function (context, userId) {
-      if (!userId) {
-        userId = ''
-      }
-      axios.get('/api/problems/' + userId).then((response) => {
+      const url = userId ? '/api/problems/' + userId : '/api/problems'
+      axios.get(url).then((response) => {
         context.commit('SET_PROBLEMS', { problems: response.data })
       })
     },


### PR DESCRIPTION
This commit fixes the bug where the defendant-frontend would have hundreds of blank problems on load.

The bug was caused by the initial problems request being made to `/api/problems/` which returned a 404. This fix was to update the problems url when the frontend doesn't have a user id yet to be `/api/problems`.