### PR TITLE
fix bug showing wrong source code for local run

### DIFF
--- a/code_court/defendant-frontend/src/components/Problem.vue
+++ b/code_court/defendant-frontend/src/components/Problem.vue
@@ -147,7 +147,7 @@ export default {
         id: runId,
         problemSlug: this.problem.slug,
         language: this.lang,
-        source_code: this.sourceCode,
+        source_code: this.$refs.editor.editor.getValue(),
         run_input: isSubmission ? null : this.testInput,
         is_submission: isSubmission,
         is_passed: null,


### PR DESCRIPTION
Sometimes when a user submitted a run, the correct source code would be submitted, but old source code was displayed for that run locally.

This was caused by the use of `this.sourceCode` to get the source for making the fake local run. `this.sourceCode` lags behind the actual value of the editor because of vue's update mechanism. This change updates the fake local run to get the source code directly from the editor, like the code for submitting runs.