### PR TITLE
remove email in favor of username

### DIFF
--- a/code_court/courthouse/model.py
+++ b/code_court/courthouse/model.py
@@ -196,13 +196,10 @@ class User(Base, UserMixin):
 
     id = Column(Integer, primary_key=True)
 
-    email = Column(String, unique=True, nullable=False)
-    """str: the user's email"""
-
     name = Column(String, nullable=False)
     """str: the user's full name, no specific format is assumed"""
 
-    username = Column(String, nullable=False)
+    username = Column(String, unique=True, nullable=False)
     """str: the username, for display"""
 
     hashed_password = Column(String, nullable=False)
@@ -221,14 +218,13 @@ class User(Base, UserMixin):
         "UserRole", secondary=user_user_role, back_populates="users")
 
     def __init__(self,
-                 email,
+                 username,
                  name,
                  password,
                  creation_time=None,
                  misc_data=None,
                  contests=None,
-                 user_roles=None,
-                 username=None):
+                 user_roles=None):
         if misc_data is None:
             misc_data = json.dumps({})
 
@@ -241,14 +237,10 @@ class User(Base, UserMixin):
         if contests is not None:
             self.contests = contests
 
-        self.email = email
         self.name = name
         self.hashed_password = str(util.hash_password(password))
         self.misc_data = misc_data
-        if username:
-            self.username = username
-        else:
-            self.username = email.split("@")[0]
+        self.username = username
 
     @property
     def misc_data_dict(self):
@@ -278,18 +270,17 @@ class User(Base, UserMixin):
         return False
 
     def get_id(self):
-        return self.email
+        return self.username
 
     def get_output_dict(self):
         return {
             "id": self.id,
-            "email": self.email,
             "name": self.name,
             "username": self.username,
         }
 
     def __repr__(self):
-        return "User({})".format(self.email)
+        return "User({})".format(self.username)
 
     def __str__(self):
         return self.__repr__()

--- a/code_court/courthouse/templates/auth/login.html
+++ b/code_court/courthouse/templates/auth/login.html
@@ -23,7 +23,7 @@
         <div class="col-md-offset-4 col-md-4">
             <form action="{{ url_for("auth.login_submit") }}" method="POST" class="form-login">
                 <h3>Please login</h3>
-                <input type="email" class="form-control input-sm" placeholder="email" name="email" />
+                <input type="text" class="form-control input-sm" placeholder="username" name="username" />
                 </br>
                 <input type="password" class="form-control input-sm" placeholder="password" name="password" />
                 </br>

--- a/code_court/courthouse/templates/auth/profile.html
+++ b/code_court/courthouse/templates/auth/profile.html
@@ -8,8 +8,8 @@
             <td>{{ current_user.name }}</td>
         </tr>
         <tr>
-            <td><strong>email</strong></td>
-            <td>{{ current_user.email }}</td>
+            <td><strong>username</strong></td>
+            <td>{{ current_user.username }}</td>
         </tr>
         <tr>
             <td><strong>roles</strong></td>

--- a/code_court/courthouse/templates/contests/add_edit.html
+++ b/code_court/courthouse/templates/contests/add_edit.html
@@ -57,8 +57,8 @@
         </label>
     </div>
     <div class="form-group">
-        <label for="users">Users</label> — Choose from: {{ user_emails }}
-        <textarea type="text" class="form-control" id="users" name="users" placeholder="Users" rows="10">{% for user in contest.users %}{{ user.email }}
+        <label for="users">Users</label> — Choose from: {{ user_usernames }}
+        <textarea type="text" class="form-control" id="users" name="users" placeholder="Users" rows="10">{% for user in contest.users %}{{ user.username }}
 {% endfor %}</textarea>
     </div>
     <div class="form-group">

--- a/code_court/courthouse/templates/navbase.html
+++ b/code_court/courthouse/templates/navbase.html
@@ -29,8 +29,8 @@
                 {% endif %}
             </ul>
             <span class="navbar-right">
-                {% if current_user.email %}
-                    <p class="navbar-text">logged in as <strong><a href="/profile">{{ current_user.email }}</strong></a></p>
+                {% if current_user.username %}
+                    <p class="navbar-text">logged in as <strong><a href="/profile">{{ current_user.username }}</strong></a></p>
                     <a href="{{ url_for('auth.logout_submit') }}" class="btn btn-default navbar-btn btn-xs">Log out</a>
                 {% else %}
                     <a href="{{ url_for('auth.login_submit') }}" class="btn btn-default navbar-btn btn-xs">Log in</a>

--- a/code_court/courthouse/templates/users/add_edit.html
+++ b/code_court/courthouse/templates/users/add_edit.html
@@ -11,12 +11,6 @@
     {% if user.id %}
         <input type="hidden" name="user_id" value="{{ user.id }}">
     {% endif %}
-
-    <div class="form-group">
-        <label for="name">Email*</label>
-        <input type="email" class="form-control" id="email" name="email"
-               placeholder="email@example.org" value="{{ user.email }}" required>
-    </div>
     <div class="form-group">
         <label for="name">Name*</label>
         <input type="text" class="form-control" id="name" name="name" placeholder="Name" value="{{ user.name }}" required>
@@ -27,12 +21,12 @@
     </div>
     <div class="form-group">
         <label for="password">Password{% if not user.hashed_password %}*{% endif %}</label>
-        <input type="password" class="form-control" id="password" name="password" 
+        <input type="password" class="form-control" id="password" name="password"
             placeholder="Password"{% if not user.hashed_password %}required{% endif %}></input>
     </div>
     <div class="form-group">
         <label for="confirm_password">Confirm Password{% if not user.hashed_password %}*{% endif %}</label>
-        <input type="password" class="form-control" id="confirm_password" name="confirm_password" 
+        <input type="password" class="form-control" id="confirm_password" name="confirm_password"
             placeholder="Confirm Password"{% if not user.hashed_password %}required{% endif %}></input>
     </div>
     <div class="form-group">

--- a/code_court/courthouse/templates/users/view.html
+++ b/code_court/courthouse/templates/users/view.html
@@ -5,7 +5,7 @@
     <div class="row">
         <div class="form-group col-xs-9 col-sm-10">
             <input type="text" class="form-control" id="search" name="search"
-                placeholder="Search term partial matches with user name or email"
+                placeholder="Search term partial matches with username"
                 {% if search %} value="{{ search }}" {% endif %}>
         </div>
         <div class="form-group col-xs-3 col-sm-2">
@@ -39,7 +39,6 @@
     <thead>
         <tr>
             <th>id</th>
-            <th>email</th>
             <th>name</th>
             <th>username</th>
             <th>user_role</th>
@@ -52,7 +51,6 @@
         {% for user in users %}
         <tr>
             <td class="user_id">{{ user.id }}</td>
-            <td class="user_email">{{ user.email }}</td>
             <td class="user_name">{{ user.name }}</td>
             <td class="user_username">{{ user.username }}</td>
             <td class="user_role">{% for user_role in user.user_roles %}{{ user_role.name }} {% endfor %}</td>

--- a/code_court/courthouse/test/api_test.py
+++ b/code_court/courthouse/test/api_test.py
@@ -24,7 +24,7 @@ class APITestCase(BaseTest):
         wrong_auth_headers = {
             'Authorization':
             'Basic %s' %
-            b64encode(b"wronguser@example.org:wrongpass").decode("ascii")
+            b64encode(b"wronguser:wrongpass").decode("ascii")
         }
         rv = self.app.get('/api/get-writ', headers=wrong_auth_headers)
         self.assertEqual(rv.status_code, 401)
@@ -36,7 +36,7 @@ class APITestCase(BaseTest):
         auth_headers = {
             'Authorization':
             'Basic %s' %
-            b64encode(b"testexec@example.org:epass").decode("ascii")
+            b64encode(b"testexec:epass").decode("ascii")
         }
 
         # get writ
@@ -96,7 +96,7 @@ class APITestCase(BaseTest):
         db_session.commit()
 
         setup_contest()
-        self.login("admin@example.org", "pass")
+        self.login("admin", "pass")
 
         test_run = model.Run.query.first()
 
@@ -117,7 +117,7 @@ class APITestCase(BaseTest):
             auth_headers = {
                 'Authorization':
                 'Basic %s' %
-                b64encode(b"testexec@example.org:epass").decode("ascii")
+                b64encode(b"testexec:epass").decode("ascii")
             }
 
             rv = self.app.get('/api/get-writ', headers=auth_headers)
@@ -132,7 +132,7 @@ class APITestCase(BaseTest):
     def test_submit_run(self):
         """Tests the run submit endpoint"""
         setup_contest()
-        token = self.get_jwt_token("testuser@example.org", "pass")
+        token = self.get_jwt_token("testuser", "pass")
 
         data = dict(
             lang="python",
@@ -148,7 +148,7 @@ class APITestCase(BaseTest):
     def test_get_problems(self):
         """Tests the /api/problems endpoint"""
         setup_contest()
-        token = self.get_jwt_token("testuser@example.org", "pass")
+        token = self.get_jwt_token("testuser", "pass")
 
         rv = self.jwt_get('/api/problems', auth_token=token)
         self.assertEqual(rv.status_code, 200)
@@ -161,19 +161,18 @@ class APITestCase(BaseTest):
     def test_get_current_user(self):
         """Tests the /api/current-user endpoint"""
         setup_contest()
-        token = self.get_jwt_token("testuser@example.org", "pass")
+        token = self.get_jwt_token("testuser", "pass")
 
         rv = self.jwt_get('/api/current-user', auth_token=token)
         self.assertEqual(rv.status_code, 200)
 
         user = json.loads(rv.data.decode("utf-8"))
-        self.assertEqual(user.get('email'), "testuser@example.org")
         self.assertEqual(user.get('username'), "testuser")
 
     def test_get_contest_info(self):
         """Tests the /api/get-contest-info endpoint"""
         setup_contest()
-        token = self.get_jwt_token("testuser@example.org", "pass")
+        token = self.get_jwt_token("testuser", "pass")
 
         rv = self.jwt_get('/api/get-contest-info', auth_token=token)
         self.assertEqual(rv.status_code, 200)
@@ -186,9 +185,8 @@ class APITestCase(BaseTest):
         setup_contest()
 
         data = dict(
-            email="signuptest@example.org",
-            name="Signup Test",
             username="signuptest",
+            name="Signup Test",
             password="pass",
             password2="pass",
             contest_name="test_contest",
@@ -197,7 +195,7 @@ class APITestCase(BaseTest):
         rv = self.post_json('/api/signup', data)
         self.assertEqual(rv.status_code, 200, rv.data)
 
-        token = self.get_jwt_token(data['email'], data['password'])
+        token = self.get_jwt_token(data['username'], data['password'])
         self.assertIsNotNone(token)
 
     def test_get_languages(self):
@@ -215,12 +213,12 @@ class APITestCase(BaseTest):
 def setup_contest():
     roles = {x.name: x for x in model.UserRole.query.all()}
     test_contestant = model.User(
-        "testuser@example.org",
+        "testuser",
         "Test User",
         "pass",
         user_roles=[roles['defendant']])
     test_executioner = model.User(
-        "testexec@example.org",
+        "testexec",
         "Test Executioner",
         "epass",
         user_roles=[roles['executioner']])

--- a/code_court/courthouse/test/base_test.py
+++ b/code_court/courthouse/test/base_test.py
@@ -33,17 +33,17 @@ class BaseTest(unittest.TestCase):
         logging.info("Setting up database")
         setup_database(app)
 
-    def login(self, email, password):
+    def login(self, username, password):
         with self.app:
             rv = self.app.post(
                 '/admin/login',
-                data=dict(email=email, password=password),
+                data=dict(username=username, password=password),
                 follow_redirects=True)
 
             self.assertEqual(rv.status_code, 200, "Failed to login")
             self.assertNotEqual(current_user, None, "Failed to login")
             self.assertFalse(current_user.is_anonymous, "Failed to login")
-            self.assertEqual(current_user.email, email, "Failed to login")
+            self.assertEqual(current_user.username, username, "Failed to login")
 
             return rv
 
@@ -55,9 +55,9 @@ class BaseTest(unittest.TestCase):
 
             return rv
 
-    def get_jwt_token(self, email, password):
+    def get_jwt_token(self, username, password):
         rv = self.app.post('/api/login', data=json.dumps({
-            "email": email,
+            "username": username,
             "password": password,
         }), content_type='application/json')
         j = json.loads(rv.data.decode("UTF-8"))

--- a/code_court/courthouse/test/configurations_test.py
+++ b/code_court/courthouse/test/configurations_test.py
@@ -67,7 +67,7 @@ class ConfigurationsTestCase(BaseTest):
         init_config_key = "init_config_125r32"
         edit_config_key = "edit_config_08294e"
 
-        self.login("admin@example.org", "pass")
+        self.login("admin", "pass")
 
         self._config_add(init_config_key)
         self._config_edit(init_config_key, edit_config_key)

--- a/code_court/courthouse/test/contests_test.py
+++ b/code_court/courthouse/test/contests_test.py
@@ -10,7 +10,7 @@ class ContestsTestCase(BaseTest):
     Contains tests for the contests blueprint
     """
 
-    def _contest_add(self, init_contest_name, emails):
+    def _contest_add(self, init_contest_name, usernames):
         rv = self.app.post(
             '/admin/contests/add/',
             data={
@@ -26,7 +26,7 @@ class ContestsTestCase(BaseTest):
                 "deactivate_date": "2017-01-01",
                 "deactivate_time": "16:00:00",
                 "is_public": "on",
-                "users": '\n'.join(emails),
+                "users": '\n'.join(usernames),
                 "problems": model.Problem.query.one().name,
             },
             follow_redirects=True)
@@ -38,7 +38,7 @@ class ContestsTestCase(BaseTest):
         self.assertIn(init_contest_name, page_contest_names,
                       "Contest was not added")
 
-    def _contest_edit(self, old_name, new_name, emails):
+    def _contest_edit(self, old_name, new_name, usernames):
         contest_id = model.Contest.query.filter_by(name=old_name).one().id
 
         rv = self.app.post(
@@ -57,7 +57,7 @@ class ContestsTestCase(BaseTest):
                 "deactivate_date": "2017-01-01",
                 "deactivate_time": "16:00:00",
                 "is_public": "on",
-                "users": '\n'.join(emails),
+                "users": '\n'.join(usernames),
                 "problems": model.Problem.query.one().name,
             },
             follow_redirects=True)
@@ -84,7 +84,7 @@ class ContestsTestCase(BaseTest):
         init_contest_name = "I see pea sea"
         edit_contest_name = "7er0 t1m3 4 s3gf4ult5"
 
-        self.login("admin@example.org", "pass")
+        self.login("admin", "pass")
 
         # Need to have a problem to test a contest:
         self.app.post(
@@ -116,17 +116,17 @@ class ContestsTestCase(BaseTest):
             "Fred", "George", "Jenny", "Sam", "Jo", "Joe", "Sarah", "Ben",
             "Josiah", "Micah"
         ]
-        emails = ["testuser{}@example.org".format(i) for i in range(1, 11)]
+        usernames = ["testuser{}".format(i) for i in range(1, 11)]
 
         for i in range(1, 11):
             test_contestant = model.User(
-                emails[i - 1],
+                usernames[i - 1],
                 names[i - 1],
                 "pass",
                 user_roles=[roles['defendant']])
             db_session.add(test_contestant)
 
-        self._contest_add(init_contest_name, emails[0:7])
-        self._contest_edit(init_contest_name, edit_contest_name, emails[0:7])
+        self._contest_add(init_contest_name, usernames[0:7])
+        self._contest_edit(init_contest_name, edit_contest_name, usernames[0:7])
         self._contest_del(edit_contest_name)
 

--- a/code_court/courthouse/test/languages_test.py
+++ b/code_court/courthouse/test/languages_test.py
@@ -64,7 +64,7 @@ class LanguagesTestCase(BaseTest):
         init_lang_name = "benscript49495885"
         edit_lang_name = "josiahscript31231137"
 
-        self.login("admin@example.org", "pass")
+        self.login("admin", "pass")
 
         self._lang_add(init_lang_name)
         self._lang_edit(init_lang_name, edit_lang_name)

--- a/code_court/courthouse/test/model_test.py
+++ b/code_court/courthouse/test/model_test.py
@@ -32,16 +32,11 @@ class ModelsTestCase(BaseTest):
     def test_user(self):
         """test the user table"""
         USER_ARGS = {
-            "email":
-            "testuser@example.org",
-            "name":
-            "Test A. B. User",
-            "password":
-            "1231i411das9d8as9ds8as9d8a9da09sd8a0fsdasdasdasdaskjdasdj1j2k31jklj12k312k3j21k",
-            "creation_time":
-            util.str_to_dt("2017-01-01T12:12:00Z"),
-            "misc_data":
-            '{"teacher": "Cavanaugh"}',
+            "username": "testuser",
+            "name": "Test A. B. User",
+            "password": "1231i411das9d8as9ds8as9d8a9da09sd8a0fsdasdasdasdaskjdasdj1j2k31jklj12k312k3j21k",
+            "creation_time": util.str_to_dt("2017-01-01T12:12:00Z"),
+            "misc_data": '{"teacher": "Cavanaugh"}',
         }
 
         # create and add user
@@ -50,7 +45,7 @@ class ModelsTestCase(BaseTest):
         db_session.commit()
 
         # fetch user
-        results = model.User.query.filter_by(email=USER_ARGS['email']).all()
+        results = model.User.query.filter_by(username=USER_ARGS['username']).all()
 
         self.assertEqual(len(results), 1)
 
@@ -284,16 +279,11 @@ def get_language():
 def get_user():
     """returns a test user"""
     USER_ARGS = {
-        "email":
-        "testuser@example.org",
-        "name":
-        "Test A. B. User",
-        "password":
-        "1231i411das9d8as9ds8as9d8a9da09sd8a0fsdasdasdasdaskjdasdj1j2k31jklj12k312k3j21k",
-        "creation_time":
-        util.str_to_dt("2017-01-01T12:12:00Z"),
-        "misc_data":
-        '{"teacher": "Cavanaugh"}',
+        "username": "testuser",
+        "name": "Test A. B. User",
+        "password": "1231i411das9d8as9ds8as9d8a9da09sd8a0fsdasdasdasdaskjdasdj1j2k31jklj12k312k3j21k",
+        "creation_time": util.str_to_dt("2017-01-01T12:12:00Z"),
+        "misc_data": '{"teacher": "Cavanaugh"}',
     }
 
     # create and add user

--- a/code_court/courthouse/test/problems_test.py
+++ b/code_court/courthouse/test/problems_test.py
@@ -91,7 +91,7 @@ class ProblemsTestCase(BaseTest):
         init_problem_name = "fibbonaci49495885"
         edit_problem_name = "shortestpath31231137"
 
-        self.login("admin@example.org", "pass")
+        self.login("admin", "pass")
 
         self._problem_add(init_problem_name)
         self._problem_edit(init_problem_name, edit_problem_name)

--- a/code_court/courthouse/test/users_test.py
+++ b/code_court/courthouse/test/users_test.py
@@ -10,12 +10,12 @@ class UsersTestCase(BaseTest):
     Contains tests for the users blueprint
     """
 
-    def _user_add(self, init_user_email):
+    def _user_add(self, init_user_username):
         rv = self.app.post(
             '/admin/users/add/',
             data={
                 "name": "Johnny Test",
-                "email": init_user_email,
+                "username": init_user_username,
                 "password": "password",
                 "confirm_password": "password",
                 "misc_data": "{}",
@@ -27,19 +27,18 @@ class UsersTestCase(BaseTest):
 
         rv = self.app.get('/admin/users/')
         root = html.fromstring(rv.data)
-        page_user_emails = [x.text for x in root.cssselect(".user_email")]
-        self.assertIn(init_user_email, page_user_emails, "User was not added")
+        page_user_usernames = [x.text for x in root.cssselect(".user_username")]
+        self.assertIn(init_user_username, page_user_usernames, "User was not added")
 
-    def _user_edit(self, old_email, new_email):
-        user_id = model.User.query.filter_by(email=old_email).one().id
+    def _user_edit(self, old_username, new_username):
+        user_id = model.User.query.filter_by(username=old_username).one().id
 
         rv = self.app.post(
             '/admin/users/add/',
             data={
                 "user_id": user_id,
                 "name": "Johnny Test",
-                "email": new_email,
-                "username": "",
+                "username": new_username,
                 "password": "",
                 "confirm_password": "",
                 "misc_data": "{}",
@@ -51,11 +50,11 @@ class UsersTestCase(BaseTest):
 
         rv = self.app.get('/admin/users/')
         root = html.fromstring(rv.data)
-        page_user_emails = [x.text for x in root.cssselect(".user_email")]
-        self.assertIn(new_email, page_user_emails, "User was not edited")
+        page_user_usernames = [x.text for x in root.cssselect(".user_username")]
+        self.assertIn(new_username, page_user_usernames, "User was not edited")
 
-    def _user_del(self, email):
-        user_id = model.User.query.filter_by(email=email).one().id
+    def _user_del(self, username):
+        user_id = model.User.query.filter_by(username=username).one().id
 
         rv = self.app.get(
             '/admin/users/del/{}'.format(user_id), follow_redirects=True)
@@ -63,16 +62,16 @@ class UsersTestCase(BaseTest):
 
         rv = self.app.get('/admin/users/')
         root = html.fromstring(rv.data)
-        page_user_emails = [x.text for x in root.cssselect(".user_email")]
-        self.assertNotIn(email, page_user_emails, "User was not deleted")
+        page_user_usernames = [x.text for x in root.cssselect(".user_username")]
+        self.assertNotIn(username, page_user_usernames, "User was not deleted")
 
     def test_user_crud(self):
-        init_user_email = "micah287410@gmail.com"
-        edit_user_email = "josiah12941@gmail.com"
+        init_user_username = "micah287410"
+        edit_user_username = "josiah12941"
 
-        self.login("admin@example.org", "pass")
+        self.login("admin", "pass")
 
-        self._user_add(init_user_email)
-        self._user_edit(init_user_email, edit_user_email)
-        self._user_del(edit_user_email)
+        self._user_add(init_user_username)
+        self._user_edit(init_user_username, edit_user_username)
+        self._user_del(edit_user_username)
 

--- a/code_court/courthouse/utils/load_test.py
+++ b/code_court/courthouse/utils/load_test.py
@@ -32,8 +32,8 @@ class FakeUser:
     SUBMIT_RUN_INTERVAL = 240
 
     def __init__(self):
-        self.email, self.password = self.create_user()
-        self.login_token = self.get_login_token(self.email, self.password)
+        self.username, self.password = self.create_user()
+        self.login_token = self.get_login_token(self.username, self.password)
         self.user_info = self.get_user_info()
         self.contest_info = self.get_contest_info()
 
@@ -154,22 +154,22 @@ class FakeUser:
         return self._get_api("current-user")
 
     def create_user(self):
-        admin_login_token = self.get_login_token("admin@example.org", "pass")
+        admin_login_token = self.get_login_token("admin", "pass")
         user_id = random.randint(1000, 1_000_000)
         data = dict(
-            email="{}@example.org".format(user_id),
+            username=str(user_id),
             name=user_id,
             password="pass",
             username=user_id,
             contest_name="test_contest",
         )
         self._post_api("make-defendant-user", data, login_token=admin_login_token)
-        return (data['email'], data['password'])
+        return (data['username'], data['password'])
 
-    def get_login_token(self, email, password):
+    def get_login_token(self, username, password):
         url = urljoin(BASE_URL, "login")
         data = dict(
-            email=email,
+            username=username,
             password=password,
         )
 

--- a/code_court/courthouse/utils/query_db.py
+++ b/code_court/courthouse/utils/query_db.py
@@ -25,11 +25,11 @@ def _main():
         IPython.embed()
 
 
-def submit_fake_run(email):
+def submit_fake_run(username):
     lang = model.Language.query.filter_by(name="python").scalar()
     problem = model.Problem.query.first()
     contest = model.Contest.query.first()
-    user = model.User.query.filter_by(email=email).scalar()
+    user = model.User.query.filter_by(username=username).scalar()
 
     run_input = problem.secret_input
     run_output = problem.secret_output

--- a/code_court/courthouse/views/admin/configurations.py
+++ b/code_court/courthouse/views/admin/configurations.py
@@ -161,7 +161,7 @@ def is_dup_config_key(key):
         key (str): the config key to test
 
     Returns:
-        bool: True if the email is a duplicate, False otherwise
+        bool: True if the key is a duplicate, False otherwise
     """
     dup_config = model.Configuration.query.filter_by(key=key).scalar()
     if dup_config:

--- a/code_court/courthouse/views/admin/contests.py
+++ b/code_court/courthouse/views/admin/contests.py
@@ -92,11 +92,11 @@ def contests_del(contest_id):
     return redirect(url_for("contests.contests_view"))
 
 
-def users_from_emails(emails, model):
+def users_from_usernames(usernames, model):
     users = []
 
-    for email in emails:
-        db_user = model.User.query.filter_by(email=email).scalar()
+    for username in usernames:
+        db_user = model.User.query.filter_by(username=username).scalar()
         if db_user:
             users.append(db_user)
     return users
@@ -134,7 +134,7 @@ def add_contest():
     deactivate_date = request.form.get("deactivate_date")
     deactivate_time = request.form.get("deactivate_time")
     is_public = request.form.get("is_public")
-    user_emails = request.form.get("users")
+    user_usernames = request.form.get("users")
     problem_slugs = request.form.get("problems")
 
     if activate_date is not "" and activate_time is not "":
@@ -149,7 +149,7 @@ def add_contest():
 
     if deactivate_date is not "" and deactivate_time is not "":
         deactivate_date_time = util.strs_to_dt(deactivate_date,
-                                                deactivate_time)
+                                               deactivate_time)
     else:
         deactivate_date_time = None
 
@@ -180,7 +180,7 @@ def add_contest():
         contest.end_time = util.strs_to_dt(end_date, end_time)
         contest.deactivate_time = deactivate_date_time
 
-        contest.users = users_from_emails(user_emails.split(), model)
+        contest.users = users_from_usernames(user_usernames.split(), model)
         contest.problems = problems_from_slugs(problem_slugs.split(), model)
     else:  # add
         if is_dup_contest_name(name):
@@ -198,7 +198,7 @@ def add_contest():
             freeze_time=freeze_date_time,
             end_time=util.strs_to_dt(end_date, end_time),
             deactivate_time=deactivate_date_time,
-            users=users_from_emails(user_emails.split(), model),
+            users=users_from_usernames(user_usernames.split(), model),
             problems=problems_from_slugs(problem_slugs.split(), model))
         db_session.add(contest)
 
@@ -226,7 +226,7 @@ def display_contest_add_form(contest_id):
             "contests/add_edit.html",
             action_label="Add",
             contest=None,
-            user_emails=[user.email for user in model.User.query.all()],
+            user_usernames=[user.username for user in model.User.query.all()],
             problem_slugs=[a.slug for a in model.Problem.query.all()])
     else:  # edit
         contest = model.Contest.query.filter_by(id=util.i(contest_id)).scalar()
@@ -241,7 +241,7 @@ def display_contest_add_form(contest_id):
             "contests/add_edit.html",
             action_label="Edit",
             contest=contest,
-            user_emails=[user.email for user in model.User.query.all()],
+            user_usernames=[user.username for user in model.User.query.all()],
             problem_slugs=[a.slug for a in model.Problem.query.all()])
 
 

--- a/code_court/courthouse/views/auth.py
+++ b/code_court/courthouse/views/auth.py
@@ -30,19 +30,19 @@ def login_view():
 @util.ssl_required
 def login_submit():
     """processes login requests"""
-    if "email" not in request.form:
-        flash("Email not found", "danger")
+    if "username" not in request.form:
+        flash("username not found", "danger")
         abort(401)
 
     if "password" not in request.form:
         flash("Password not found", "danger")
         abort(401)
 
-    email = request.form.get("email")
+    username = request.form.get("username")
     password = request.form.get("password")
 
     try:
-        user = model.User.query.filter_by(email=email).one()
+        user = model.User.query.filter_by(username=username).one()
     except NoResultFound as e:
         flash("Invalid username or password", "danger")
         abort(401)

--- a/code_court/courthouse/views/defendant.py
+++ b/code_court/courthouse/views/defendant.py
@@ -83,7 +83,7 @@ def submit_code(problem):
     current_time = datetime.datetime.utcnow()
 
     # Hardcoded run details for the time being
-    test_user = model.User.query.filter_by(email="testuser1@example.org").one()
+    test_user = model.User.query.filter_by(username="testuser1").one()
     test_contest = model.Contest.query.filter_by(name="test_contest").one()
     python = model.Language.query.filter_by(name="python").one()
 

--- a/code_court/courthouse/web.py
+++ b/code_court/courthouse/web.py
@@ -103,12 +103,11 @@ def create_app():
 
     DebugToolbarExtension(app)
 
-
     app.logger.info("Setting up app")
 
     @login_manager.user_loader
-    def load_user(user_email):
-        return model.User.query.filter_by(email=user_email).scalar()
+    def load_user(username):
+        return model.User.query.filter_by(username=username).scalar()
 
     app.register_blueprint(main, url_prefix='')
     app.register_blueprint(api, url_prefix='/api')
@@ -365,12 +364,12 @@ def populate_db():
     roles = {x.name: x for x in model.UserRole.query.all()}
     db_session.add_all([
         model.User(
-            "admin@example.org",
+            "admin",
             "Admin",
             "pass",
             user_roles=[roles['operator']]),
         model.User(
-            "exec@example.org",
+            "exec",
             "Executioner",
             "epass",
             user_roles=[roles['executioner']])
@@ -383,7 +382,7 @@ def populate_db():
     with open("init_data/printver.py", "r") as f:
         src_code = "\n".join(f.readlines())
 
-    executioner_user = model.User.query.filter_by(email="exec@example.org").scalar()
+    executioner_user = model.User.query.filter_by(username="exec").scalar()
 
     python = model.Language.query.filter_by(name="python").scalar()
     empty_input = ""
@@ -417,12 +416,12 @@ def dev_populate_db():
 
     db_session.add_all([
         model.User(
-            "super@example.org",
+            "superuser",
             "SuperUser",
             "pass",
             user_roles=list(roles.values())),
         model.User(
-            "observer@example.org",
+            "observer",
             "ObserverUser",
             "pass",
             user_roles=[roles['observer']])
@@ -435,7 +434,7 @@ def dev_populate_db():
     ]
     for i in range(1, 5):
         test_contestant = model.User(
-            "testuser{}@example.org".format(i),
+            "testuser{}".format(i),
             names[i - 1],
             "pass",
             user_roles=[roles['defendant']])

--- a/code_court/defendant-frontend/src/components/Login.vue
+++ b/code_court/defendant-frontend/src/components/Login.vue
@@ -5,7 +5,7 @@
       <h3 class="title">login</h3>
       <form @submit.prevent="login()">
         <p class="control">
-          <input v-model="loginEmail" type="email" class="input" placeholder="email" name="email" required />
+          <input v-model="loginUsername" type="text" class="input" placeholder="username" name="username" />
         </p>
 
         <p class="control">
@@ -56,7 +56,7 @@
 export default {
   data () {
     return {
-      loginEmail: '',
+      loginUsername: '',
       loginPassword: '',
       signupEmail: '',
       signupUsername: '',
@@ -73,7 +73,7 @@ export default {
   },
   methods: {
     login: function () {
-      this.$store.dispatch('LOGIN', {email: this.loginEmail, password: this.loginPassword})
+      this.$store.dispatch('LOGIN', {username: this.loginUsername, password: this.loginPassword})
     },
     signup: function () {
       this.$store.dispatch('SIGNUP', {

--- a/code_court/defendant-frontend/src/components/Nav.vue
+++ b/code_court/defendant-frontend/src/components/Nav.vue
@@ -17,7 +17,7 @@
 
         <div class="level-right">
           <span v-if="!user"><router-link to="/login">Login</router-link></span>
-          <span v-if="user"><a @click.prevent="logout()" class="logout">Logout {{ user.email }}</a></span>
+          <span v-if="user"><a @click.prevent="logout()" class="logout">Logout {{ user.username }}</a></span>
         </div>
       </div>
     </div>

--- a/code_court/defendant-frontend/src/components/Scoreboard.vue
+++ b/code_court/defendant-frontend/src/components/Scoreboard.vue
@@ -8,9 +8,9 @@
           <span>Penalty</span>
           <span v-for="(state, prob) in scores[0].problem_states">{{ prob }}</span>
       </li>
-      <li v-for="(row, i) in scores" :key="row.user.email" class="table-row-item" >
+      <li v-for="(row, i) in scores" :key="row.user.username" class="table-row-item" >
           <span>{{ i+1 }}</span>
-          <span :title="row.user.email">{{ row.user.username }}</span>
+          <span :title="row.user.username">{{ row.user.username }}</span>
           <span>{{ row.num_solved }}</span>
           <span>{{ row.penalty }}</span>
           <span v-for="(state, prob) in row.problem_states" :class="{'correct': state}">
@@ -32,11 +32,6 @@ export default {
   computed: {
     scores () {
       return this.$store.state.scores
-    }
-  },
-  methods: {
-    getUsername (email) {
-      return email.split('@')[0]
     }
   }
 }

--- a/code_court/defendant-frontend/src/store/index.js
+++ b/code_court/defendant-frontend/src/store/index.js
@@ -49,7 +49,7 @@ const store = new Vuex.Store({
     },
     LOGIN: function (context, creds) {
       axios.post('/api/login', {
-        email: creds.email,
+        username: creds.username,
         password: creds.password
       }).then((response) => {
         context.commit('SET_LOGIN_TOKEN', { token: response.data.access_token })

--- a/code_court/executor/executor.py
+++ b/code_court/executor/executor.py
@@ -129,7 +129,7 @@ class Executor:
         try:
             r = requests.get(
                 self.conf['writ_url'],
-                auth=HTTPBasicAuth(self.conf['email'], self.conf['password'])
+                auth=HTTPBasicAuth(self.conf['username'], self.conf['password'])
             )
         except Exception:
             logging.warn("Couldn't to courthouse at %s", self.conf['writ_url'])
@@ -153,7 +153,7 @@ class Executor:
             r = requests.post(
                 self.conf['submit_url'].format(self.writ.run_id),
                 json={"output": out, "state": state},
-                auth=HTTPBasicAuth(self.conf['email'], self.conf['password'])
+                auth=HTTPBasicAuth(self.conf['username'], self.conf['password'])
             )
 
             if r.status_code != 200:
@@ -171,7 +171,7 @@ class Executor:
         try:
             requests.post(
                 url,
-                auth=HTTPBasicAuth(self.conf['email'], self.conf['password'])
+                auth=HTTPBasicAuth(self.conf['username'], self.conf['password'])
             )
         except requests.exceptions.ConnectionError:
             logging.warn("Failed to return writ: %s", self.writ.run_id)
@@ -314,16 +314,15 @@ def get_conf():
         help='executes writs locally without docker in an insecure manner',
     )
     parser.add_argument(
-        '-u',
         '--url',
         default="http://localhost:9191",
         help='the courthouse url',
     )
     parser.add_argument(
-        '-e',
-        '--email',
-        default='exec@example.org',
-        help='the email for the executor user',
+        '-u',
+        '--username',
+        default='exec',
+        help='the username for the executor user',
     )
     parser.add_argument(
         '-p',

--- a/code_court/make_users.sh
+++ b/code_court/make_users.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-token=$(curl -sH "Content-Type: application/json" --data '{"email": "admin@example.org", "password": "pass"}' http://codecourt.org/api/login | jq -r ".access_token")
+token=$(curl -sH "Content-Type: application/json" --data '{"username": "admin", "password": "pass"}' http://codecourt.org/api/login | jq -r ".access_token")
 
 for i in {2..110}; do
     echo $i
-    curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" --data "{\"name\": \"Test\", \"email\": \"testuser$i@example.org\", \"password\": \"pass\", \"contest_name\": \"UNO\", \"username\": \"testuser$i\"}" http://codecourt.org/api/make-defendant-user
+    curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" --data "{\"name\": \"Test\", \"username\": \"testuser$i\", \"password\": \"pass\", \"contest_name\": \"UNO\"}" http://codecourt.org/api/make-defendant-user
 done


### PR DESCRIPTION
Email is currently used everywhere as the primary identifier of a user, i.e. for logging in, for querying users, etc.

Using username instead of email makes the system more flexible. For instance, if teams are competing they may not have an email that makes sense to use.

This change removes the email field from the user model and replaces all usages of it with the username.